### PR TITLE
For the app to work on the hosted server - cosc360

### DIFF
--- a/extensionScripts/config.php
+++ b/extensionScripts/config.php
@@ -1,8 +1,5 @@
 <?php
-define("DBHOST", "localhost");
-define("DB_USER", "root");
-define("DB_PASSWORD", "");
-define("DB_NAME", "gunited");
 
-$connString = "mysql:host=".DBHOST.";dbname=".DB_NAME;
+require "../dbConfig.php";
+
 ?>


### PR DESCRIPTION
We need to abstract the config file out of the repo for the site to work on the cosc360 server. Follow that naming convention, and create a dbConfig.php file outside the G-United repo with those credentials to work locally:

define("DBHOST", "localhost");
define("DB_USER", "root");
define("DB_PASSWORD", "");
define("DB_NAME", "gunited");

$connString = "mysql:host=".DBHOST.";dbname=".DB_NAME;

![image](https://github.com/yemoski/G-United/assets/87030215/6acafa9a-647e-4d81-a9a6-1630840b19b7)
